### PR TITLE
Added snippet to generate and install favicons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ RUN add-pkg --virtual build-dependencies py3-pkgconfig python3-dev py3-virtualen
 RUN    pip3 install --break-system-packages borgbackup vorta pyfuse3 
 RUN    del-pkg build-dependencies
 
+# Generate and install favicons.
+RUN \
+    APP_ICON_URL=hhttps://files.qmax.us/vorta/vorta-512px.png && \
+    install_app_icon.sh "$APP_ICON_URL"
+
 # Copy the start script and force permissions just in case
 COPY --chmod=755 rootfs/ /
 


### PR DESCRIPTION
My first ever PR so I hope I've done this right.

I thought the Docker container needed a Vorta favicon instead of the blue box. Followed the [instructions](https://github.com/jlesage/docker-baseimage-gui/tree/master?tab=readme-ov-file#application-icon) for the baseimage from jlesage.
The image link is from the [Vorta README.md](https://github.com/borgbase/vorta/blob/master/README.md)

Maybe it's best to instead add the icon to the repo instead of using this link, but that might need a separate PR first so the link is right? 